### PR TITLE
Defer refresh rate changes when screen is off

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -36,6 +36,7 @@ PRODUCT_PACKAGES += \
 
 # Display
 PRODUCT_COPY_FILES += \
+    vendor.display.enable_fp_monitor=1 \
     $(call find-copy-subdir-files,qdcm_calib_data_*.xml,$(LOCAL_PATH)/qdcm/,$(TARGET_COPY_OUT_VENDOR)/etc/)
 
 # DSP Volume Synchronizer


### PR DESCRIPTION
Some devices with video mode panels experience refresh rate mismatches when the screen is turned off. Specifically:
- The scheduler sets the refresh rate to 120 Hz after the screen turns off at 60 Hz (VRR idle).
- However, the HWC ignores this change, resulting in SurfaceFlinger (SF) incorrectly assuming the device is at 120 Hz when the display is turned back on.
- This causes a mismatch, as HWC continues rendering at 60 Hz, leading to inconsistencies.

To enable this behavior, set the following property:
- `debug.sf.defer_refresh_rate_when_off=1`